### PR TITLE
Renamed intermediate classes

### DIFF
--- a/MNCoder/IntermediateObjects/MNCAttributedString.h
+++ b/MNCoder/IntermediateObjects/MNCAttributedString.h
@@ -33,14 +33,14 @@
 extern NSString *const kMNAttributedStringAttributeAttributeKey;
 extern NSString *const kMNAttributedStringAttributeRangeKey;
 
-@protocol MNAttributedStringAttributeProtocol <NSObject, NSCoding>
+@protocol MNCAttributedStringAttributeProtocol <NSObject, NSCoding>
 @required
 -(NSDictionary *)platformRepresentation;
 +(BOOL)isSubstituteForObject:(void *)object;
 -(id)initWithAttributeName:(NSString *)attributeName value:(void *)object range:(NSRange)range forAttributedString:(NSAttributedString *)string;
 @end
 
-@interface MNAttributedString : NSObject <MNCIntermediateObjectProtocol> {
+@interface MNCAttributedString : NSObject <MNCIntermediateObjectProtocol> {
 @private
 	NSMutableSet *__substituteClasses;
     

--- a/MNCoder/IntermediateObjects/MNCAttributedString.m
+++ b/MNCoder/IntermediateObjects/MNCAttributedString.m
@@ -27,7 +27,7 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import "MNASParagraphyStyle.h"
 #import "MNASGlyphInfo.h"
@@ -46,14 +46,14 @@
 NSString *const kMNAttributedStringAttributeAttributeKey = @"kMNAttributedStringAttributeAttributeKey";
 NSString *const kMNAttributedStringAttributeRangeKey = @"kMNAttributedStringAttributeRangeKey";
 
-@interface MNAttributedString (/* Private Methods */)
+@interface MNCAttributedString (/* Private Methods */)
 -(void)_buildIntermediateRepresentationFromString:(NSAttributedString *)string;
 -(NSDictionary *)_dictionaryForAttributes:(NSDictionary *)attrs range:(NSRange)aRange;
 +(NSRange)_rangeFromRangeDictionaryItem:(id)rangeItem;
 +(NSString *)_rangeStringFromRange:(NSRange)range;
 @end
 
-@implementation MNAttributedString
+@implementation MNCAttributedString
 @synthesize string = _string, attributes = _attributes;
 
 #pragma mark - NSCoding Protocol
@@ -125,7 +125,7 @@ NSString *const kMNAttributedStringAttributeRangeKey = @"kMNAttributedStringAttr
 
         attributeObj = [dict objectForKey:kMNAttributedStringAttributeAttributeKey];
         
-        if ([attributeObj conformsToProtocol:@protocol(MNAttributedStringAttributeProtocol)]) {
+        if ([attributeObj conformsToProtocol:@protocol(MNCAttributedStringAttributeProtocol)]) {
             attributeToInsert = [attributeObj platformRepresentation];
         } else {
             attributeToInsert = attributeObj;
@@ -175,7 +175,7 @@ NSString *const kMNAttributedStringAttributeRangeKey = @"kMNAttributedStringAttr
 			} else {
 				NSLog(@"Attribute not translated ->> (%@): %@", key, [attrs objectForKey:key]);
 				
-				if (([MNAttributedString lossless]) && ([[attrs objectForKey:key] conformsToProtocol:@protocol(NSCoding)])) {
+				if (([MNCAttributedString lossless]) && ([[attrs objectForKey:key] conformsToProtocol:@protocol(NSCoding)])) {
 					[attributes insertObject:[self _dictionaryForAttributes:[NSDictionary dictionaryWithObject:[attrs objectForKey:key] forKey:key] range:range] atIndex:([attributes count]-1)];
 				}
 			}
@@ -223,12 +223,12 @@ NSString *const kMNAttributedStringAttributeRangeKey = @"kMNAttributedStringAttr
 
 #pragma mark - Substitute Class Methods
 -(void)registerSubstituteClass:(Class)cls {
-    if ([cls conformsToProtocol:@protocol(MNAttributedStringAttributeProtocol)])
+    if ([cls conformsToProtocol:@protocol(MNCAttributedStringAttributeProtocol)])
         [__substituteClasses addObject:cls];
 }
 
 -(void)unregisterSubtituteClass:(Class)cls {
-    if ([cls conformsToProtocol:@protocol(MNAttributedStringAttributeProtocol)])
+    if ([cls conformsToProtocol:@protocol(MNCAttributedStringAttributeProtocol)])
         [__substituteClasses removeObject:cls];
 }
 

--- a/MNCoder/IntermediateObjects/MNCColor.h
+++ b/MNCoder/IntermediateObjects/MNCColor.h
@@ -35,7 +35,7 @@
 
 #import "MNCIntermediateObjectProtocol.h"
 
-@interface MNColor : NSObject <MNCIntermediateObjectProtocol> {
+@interface MNCColor : NSObject <MNCIntermediateObjectProtocol> {
 @private
     CGFloat _red;
     CGFloat _green;

--- a/MNCoder/IntermediateObjects/MNCColor.m
+++ b/MNCoder/IntermediateObjects/MNCColor.m
@@ -1,5 +1,5 @@
 //
-//  MNFont.m
+//  MNColor.m
 //  MNCoder
 //
 //  Created by Jeremy Foo on 1/7/12.
@@ -27,95 +27,86 @@
 
 //
 
-#import "MNFont.h"
+#import "MNCColor.h"
 
-@implementation MNFont
-@synthesize fontName = _fontName, size = _size;
+@implementation MNCColor
+@synthesize red = _red, green = _green, blue = _blue, alpha = _alpha;
 
 #pragma mark - NSCoding Protocol
 
 -(id)initWithCoder:(NSCoder *)aDecoder {
 	if ((self = [super init])) {
-		_fontName = [[aDecoder decodeObjectForKey:@"fontName"] copy];
-		_size = [aDecoder decodeFloatForKey:@"size"];
+		_red = [aDecoder decodeFloatForKey:@"red"];
+		_green = [aDecoder decodeFloatForKey:@"green"];
+		_blue = [aDecoder decodeFloatForKey:@"blue"];
+		_alpha = [aDecoder decodeFloatForKey:@"alpha"];
 	}
 	
 	return self;
 }
 
 -(void)encodeWithCoder:(NSCoder *)aCoder {
-	[aCoder encodeObject:self.fontName forKey:@"fontName"];
-	[aCoder encodeFloat:self.size forKey:@"size"];
-}
-
--(void)dealloc {
-	[_fontName release], _fontName = nil;
-	[super dealloc];
+	[aCoder encodeFloat:self.red forKey:@"red"];
+	[aCoder encodeFloat:self.green forKey:@"green"];
+	[aCoder encodeFloat:self.blue forKey:@"blue"];
+	[aCoder encodeFloat:self.alpha forKey:@"alpha"];
 }
 
 #pragma mark - Platform specific representation
 
 #if TARGET_OS_IPHONE
 
--(id)initWithFont:(UIFont *)font {
+-(id)initWithColor:(UIColor *)color {
 	if ((self = [super init])) {
-		_fontName = [font.fontName copy] ;
-		_size = font.pointSize;
+		[color getRed:&_red green:&_green blue:&_blue alpha:&_alpha];
 	}
 	return self;
 }
 
--(UIFont *)font {
-    UIFont *test = [UIFont fontWithName:self.fontName size:self.size];
-    
-    if (test) {
-        return test;
-    } else {
-        return [UIFont systemFontOfSize:self.size];
-    }
+-(UIColor *)color {
+	return [UIColor colorWithRed:self.red green:self.green blue:self.blue alpha:self.alpha];
 }
 
 #else
 
--(id)initWithFont:(NSFont *)font {
+-(id)initWithColor:(NSColor *)color {
 	if ((self = [super init])) {
-		_fontName = [font.fontName copy];
-		_size = font.pointSize;
+        
+		NSColor *calibratedColor = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
+        
+        _red = [calibratedColor redComponent];
+        _green = [calibratedColor greenComponent];
+        _blue = [calibratedColor blueComponent];
+        _alpha = [calibratedColor alphaComponent];
 	}
 	return self;
 }
 
--(NSFont *)font {
-    NSFont *test = [NSFont fontWithName:self.fontName size:self.size];
-    
-    if (test) {
-        return test;
-    } else {
-        return [NSFont systemFontOfSize:self.size];
-    }
+-(NSColor *)color {
+	return [NSColor colorWithCalibratedRed:self.red green:self.green blue:self.blue alpha:self.alpha];
 }
 #endif
 
 -(NSString *)description {
-    return [NSString stringWithFormat:@"MNFont: fontName(%@) pointSize(%f)", self.fontName, self.size];
+    return [NSString stringWithFormat:@"MNColor: red(%f) green(%f) blue(%f) alpha(%f)", self.red, self.green, self.blue, self.alpha];
 }
-
 
 #pragma mark - MNCIntermediateObject Protocol
 
 -(id)initWithSubsituteObject:(void *)object {
-	return [self initWithFont:(id)object];
+	return [self initWithColor:object];
 }
 
 +(BOOL)isSubstituteForObject:(void *)object {
 #if TARGET_OS_IPHONE 
-	return [(id)object isKindOfClass:[UIFont class]];
+	return [(id)object isKindOfClass:[UIColor class]];
 #else
-	return [(id)object isKindOfClass:[NSFont class]];
+	return [(id)object isKindOfClass:[NSColor class]];
 #endif
 }
 
 -(id)platformRepresentation {
-	return [self font];
+	return [self color];
 }
+
 @end

--- a/MNCoder/IntermediateObjects/MNCFont.h
+++ b/MNCoder/IntermediateObjects/MNCFont.h
@@ -35,7 +35,7 @@
 
 #import "MNCIntermediateObjectProtocol.h"
 
-@interface MNFont : NSObject <MNCIntermediateObjectProtocol> {
+@interface MNCFont : NSObject <MNCIntermediateObjectProtocol> {
 @private
     NSString *_fontName;
     CGFloat _size;

--- a/MNCoder/IntermediateObjects/MNCFont.m
+++ b/MNCoder/IntermediateObjects/MNCFont.m
@@ -1,5 +1,5 @@
 //
-//  MNColor.m
+//  MNFont.m
 //  MNCoder
 //
 //  Created by Jeremy Foo on 1/7/12.
@@ -27,86 +27,95 @@
 
 //
 
-#import "MNColor.h"
+#import "MNCFont.h"
 
-@implementation MNColor
-@synthesize red = _red, green = _green, blue = _blue, alpha = _alpha;
+@implementation MNCFont
+@synthesize fontName = _fontName, size = _size;
 
 #pragma mark - NSCoding Protocol
 
 -(id)initWithCoder:(NSCoder *)aDecoder {
 	if ((self = [super init])) {
-		_red = [aDecoder decodeFloatForKey:@"red"];
-		_green = [aDecoder decodeFloatForKey:@"green"];
-		_blue = [aDecoder decodeFloatForKey:@"blue"];
-		_alpha = [aDecoder decodeFloatForKey:@"alpha"];
+		_fontName = [[aDecoder decodeObjectForKey:@"fontName"] copy];
+		_size = [aDecoder decodeFloatForKey:@"size"];
 	}
 	
 	return self;
 }
 
 -(void)encodeWithCoder:(NSCoder *)aCoder {
-	[aCoder encodeFloat:self.red forKey:@"red"];
-	[aCoder encodeFloat:self.green forKey:@"green"];
-	[aCoder encodeFloat:self.blue forKey:@"blue"];
-	[aCoder encodeFloat:self.alpha forKey:@"alpha"];
+	[aCoder encodeObject:self.fontName forKey:@"fontName"];
+	[aCoder encodeFloat:self.size forKey:@"size"];
+}
+
+-(void)dealloc {
+	[_fontName release], _fontName = nil;
+	[super dealloc];
 }
 
 #pragma mark - Platform specific representation
 
 #if TARGET_OS_IPHONE
 
--(id)initWithColor:(UIColor *)color {
+-(id)initWithFont:(UIFont *)font {
 	if ((self = [super init])) {
-		[color getRed:&_red green:&_green blue:&_blue alpha:&_alpha];
+		_fontName = [font.fontName copy] ;
+		_size = font.pointSize;
 	}
 	return self;
 }
 
--(UIColor *)color {
-	return [UIColor colorWithRed:self.red green:self.green blue:self.blue alpha:self.alpha];
+-(UIFont *)font {
+    UIFont *test = [UIFont fontWithName:self.fontName size:self.size];
+    
+    if (test) {
+        return test;
+    } else {
+        return [UIFont systemFontOfSize:self.size];
+    }
 }
 
 #else
 
--(id)initWithColor:(NSColor *)color {
+-(id)initWithFont:(NSFont *)font {
 	if ((self = [super init])) {
-        
-		NSColor *calibratedColor = [color colorUsingColorSpaceName:NSCalibratedRGBColorSpace];
-        
-        _red = [calibratedColor redComponent];
-        _green = [calibratedColor greenComponent];
-        _blue = [calibratedColor blueComponent];
-        _alpha = [calibratedColor alphaComponent];
+		_fontName = [font.fontName copy];
+		_size = font.pointSize;
 	}
 	return self;
 }
 
--(NSColor *)color {
-	return [NSColor colorWithCalibratedRed:self.red green:self.green blue:self.blue alpha:self.alpha];
+-(NSFont *)font {
+    NSFont *test = [NSFont fontWithName:self.fontName size:self.size];
+    
+    if (test) {
+        return test;
+    } else {
+        return [NSFont systemFontOfSize:self.size];
+    }
 }
 #endif
 
 -(NSString *)description {
-    return [NSString stringWithFormat:@"MNColor: red(%f) green(%f) blue(%f) alpha(%f)", self.red, self.green, self.blue, self.alpha];
+    return [NSString stringWithFormat:@"MNFont: fontName(%@) pointSize(%f)", self.fontName, self.size];
 }
+
 
 #pragma mark - MNCIntermediateObject Protocol
 
 -(id)initWithSubsituteObject:(void *)object {
-	return [self initWithColor:object];
+	return [self initWithFont:(id)object];
 }
 
 +(BOOL)isSubstituteForObject:(void *)object {
 #if TARGET_OS_IPHONE 
-	return [(id)object isKindOfClass:[UIColor class]];
+	return [(id)object isKindOfClass:[UIFont class]];
 #else
-	return [(id)object isKindOfClass:[NSColor class]];
+	return [(id)object isKindOfClass:[NSFont class]];
 #endif
 }
 
 -(id)platformRepresentation {
-	return [self color];
+	return [self font];
 }
-
 @end

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASCharacterShape.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASCharacterShape.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASCharacterShape : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASCharacterShape : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSNumber *_shapeType;
 }

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASFont.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASFont.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASFont : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASFont : NSObject <MNCAttributedStringAttributeProtocol> {
 @private;
     NSString *_fontName;
     CGFloat _size;

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASFont.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASFont.m
@@ -84,7 +84,7 @@
         
         CTFontDescriptorRef fontDesc;
         
-        if ([MNAttributedString hasUIKitAdditions]) {
+        if ([MNCAttributedString hasUIKitAdditions]) {
             if ([attributeName isEqualToString:NSFontAttributeName]) {
                 UIFont *theFont = (UIFont *)object;
                                 

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASForegroundColor.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASForegroundColor.h
@@ -28,7 +28,7 @@
 //
 
 #import "MNCAttributedString.h"
-#import "MNColor.h"
+#import "MNCColor.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASForegroundColor.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASForegroundColor.h
@@ -27,7 +27,7 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 #import "MNColor.h"
 
 #import <Foundation/Foundation.h>
@@ -35,7 +35,7 @@
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASForegroundColor : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASForegroundColor : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     
 #if TARGET_OS_IPHONE

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASGlyphInfo.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASGlyphInfo.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASGlyphInfo : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASGlyphInfo : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSUInteger _characterCollection;
     NSUInteger _characterIdentifier;

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASKern.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASKern.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASKern : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASKern : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSNumber *_kern;
 }

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASKern.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASKern.m
@@ -65,7 +65,7 @@
 
 -(NSDictionary *)platformRepresentation {
 #if TARGET_OS_IPHONE
-    if ([MNAttributedString hasUIKitAdditions]) {
+    if ([MNCAttributedString hasUIKitAdditions]) {
         return [NSDictionary dictionaryWithObject:self.kern forKey:NSKernAttributeName];
         
     } else {

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASLigature.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASLigature.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASLigature : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASLigature : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSNumber *_type;
 

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASLigature.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASLigature.m
@@ -65,7 +65,7 @@
 
 -(NSDictionary *)platformRepresentation {
 #if TARGET_OS_IPHONE
-    if ([MNAttributedString hasUIKitAdditions]) {
+    if ([MNCAttributedString hasUIKitAdditions]) {
         return [NSDictionary dictionaryWithObject:self.type forKey:NSLigatureAttributeName];
 
     } else {

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASParagraphyStyle.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASParagraphyStyle.h
@@ -32,9 +32,9 @@
 #import <CoreText/CoreText.h>
 #endif
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
-@interface MNASParagraphyStyle : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASParagraphyStyle : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSUInteger _alignment;
     CGFloat _firstLineHeadIndent;

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASParagraphyStyle.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASParagraphyStyle.m
@@ -86,7 +86,7 @@
 -(NSDictionary *)platformRepresentation {
 #if TARGET_OS_IPHONE
     
-    if ([MNAttributedString hasUIKitAdditions]) {
+    if ([MNCAttributedString hasUIKitAdditions]) {
         NSMutableParagraphStyle *platRep = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
         
         platRep.alignment = self.alignment;

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeColor.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeColor.h
@@ -28,7 +28,7 @@
 //
 
 #import "MNCAttributedString.h"
-#import "MNColor.h"
+#import "MNCColor.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeColor.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeColor.h
@@ -27,7 +27,7 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 #import "MNColor.h"
 
 #import <Foundation/Foundation.h>
@@ -35,7 +35,7 @@
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASStrokeColor : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASStrokeColor : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
 #if TARGET_OS_IPHONE
     UIColor *_color;

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeColor.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeColor.m
@@ -74,7 +74,7 @@
 
 -(NSDictionary *)platformRepresentation {
 #if TARGET_OS_IPHONE
-    if ([MNAttributedString hasUIKitAdditions]) {
+    if ([MNCAttributedString hasUIKitAdditions]) {
         return [NSDictionary dictionaryWithObject:self.color forKey:NSStrokeColorAttributeName];
         
     } else {

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeWidth.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeWidth.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASStrokeWidth : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASStrokeWidth : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSNumber *_width;
 

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeWidth.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASStrokeWidth.m
@@ -65,7 +65,7 @@
 
 -(NSDictionary *)platformRepresentation {
 #if TARGET_OS_IPHONE
-    if ([MNAttributedString hasUIKitAdditions]) {
+    if ([MNCAttributedString hasUIKitAdditions]) {
         return [NSDictionary dictionaryWithObject:self.width forKey:NSStrokeWidthAttributeName];
 
     } else {

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASSuperScript.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASSuperScript.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASSuperScript : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASSuperScript : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSNumber *_textPosition;
 

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASUnderlineColor.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASUnderlineColor.h
@@ -27,7 +27,7 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 #import "MNColor.h"
 
 #import <Foundation/Foundation.h>
@@ -35,7 +35,7 @@
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASUnderlineColor : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASUnderlineColor : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
 #if TARGET_OS_IPHONE
     UIColor *_color;

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASUnderlineColor.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASUnderlineColor.h
@@ -28,7 +28,7 @@
 //
 
 #import "MNCAttributedString.h"
-#import "MNColor.h"
+#import "MNCColor.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASUnderlineStyle.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASUnderlineStyle.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASUnderlineStyle : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASUnderlineStyle : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     NSNumber *_styleMask;
 

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASVerticalForms.h
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASVerticalForms.h
@@ -27,14 +27,14 @@
 
 //
 
-#import "MNAttributedString.h"
+#import "MNCAttributedString.h"
 
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IPHONE
 #import <CoreText/CoreText.h>
 #endif
 
-@interface MNASVerticalForms : NSObject <MNAttributedStringAttributeProtocol> {
+@interface MNASVerticalForms : NSObject <MNCAttributedStringAttributeProtocol> {
 @private
     BOOL _enabled;
 }

--- a/MNCoder/IntermediateObjects/NSAttributedStrings/MNASVerticalForms.m
+++ b/MNCoder/IntermediateObjects/NSAttributedStrings/MNASVerticalForms.m
@@ -80,7 +80,7 @@
 -(NSDictionary *)platformRepresentation {
 #if TARGET_OS_IPHONE
 
-    if ([MNAttributedString hasUIKitAdditions]) {
+    if ([MNCAttributedString hasUIKitAdditions]) {
         return [NSDictionary dictionaryWithObject:[NSNumber numberWithBool:self.enabled] forKey:NSVerticalGlyphFormAttributeName];
     } else {
         CFBooleanRef verticalFormsEnabled;

--- a/MNCoder/MNArchiver.m
+++ b/MNCoder/MNArchiver.m
@@ -30,9 +30,9 @@
 #import "MNArchiver.h"
 #import "MNCIntermediateObjectProtocol.h"
 
-#import "MNFont.h"
-#import "MNColor.h"
-#import "MNAttributedString.h"
+#import "MNCFont.h"
+#import "MNCColor.h"
+#import "MNCAttributedString.h"
 
 @implementation MNArchiver
 
@@ -86,9 +86,9 @@
     
     MNArchiver *archiver = [[[MNArchiver alloc] initForWritingWithMutableData:resultData] autorelease];
     archiver.outputFormat = NSPropertyListBinaryFormat_v1_0;
-    [archiver registerSubstituteClass:[MNFont class]];
-    [archiver registerSubstituteClass:[MNColor class]];
-	[archiver registerSubstituteClass:[MNAttributedString class]];
+    [archiver registerSubstituteClass:[MNCFont class]];
+    [archiver registerSubstituteClass:[MNCColor class]];
+	[archiver registerSubstituteClass:[MNCAttributedString class]];
     
     [archiver encodeRootObject:object];
     

--- a/MNCoder/MNUnarchiver.m
+++ b/MNCoder/MNUnarchiver.m
@@ -43,9 +43,9 @@
 #import "MNCIntermediateObjectProtocol.h"
 
 // preconfigured intermediate objects
-#import "MNFont.h"
-#import "MNColor.h"
-#import "MNAttributedString.h"
+#import "MNCFont.h"
+#import "MNCColor.h"
+#import "MNCAttributedString.h"
 
 @implementation MNUnarchiver
 @synthesize decodedRootObject=_decodedRootObject;
@@ -92,9 +92,9 @@
 
 +(id)unarchiveObjectWithData:(NSData *)data {
     MNUnarchiver *unarchiver = [[[MNUnarchiver alloc] initForReadingWithData:data] autorelease];
-    [unarchiver registerSubstituteClass:[MNFont class]];
-    [unarchiver registerSubstituteClass:[MNColor class]];
-	[unarchiver registerSubstituteClass:[MNAttributedString class]];
+    [unarchiver registerSubstituteClass:[MNCFont class]];
+    [unarchiver registerSubstituteClass:[MNCColor class]];
+	[unarchiver registerSubstituteClass:[MNCAttributedString class]];
     
     return [[[unarchiver decodedRootObject] retain] autorelease];
 }

--- a/Mac/Mac.xcodeproj/project.pbxproj
+++ b/Mac/Mac.xcodeproj/project.pbxproj
@@ -15,9 +15,9 @@
 		3F18E41414B7D6EE00303392 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3F18E41214B7D6EE00303392 /* MainMenu.xib */; };
 		3F18E44914B7D79700303392 /* MNArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E44814B7D79700303392 /* MNArchiver.m */; };
 		3F18E45014B7D8B900303392 /* MNUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E44F14B7D8B900303392 /* MNUnarchiver.m */; };
-		3F18E46014B7DB4600303392 /* MNFont.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E45F14B7DB4600303392 /* MNFont.m */; };
-		3F18E46314B7DB5300303392 /* MNColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E46214B7DB5300303392 /* MNColor.m */; };
-		3F54A0AC14C3535D003D5928 /* MNAttributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0AB14C3535D003D5928 /* MNAttributedString.m */; };
+		3F18E46014B7DB4600303392 /* MNCFont.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E45F14B7DB4600303392 /* MNCFont.m */; };
+		3F18E46314B7DB5300303392 /* MNCColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E46214B7DB5300303392 /* MNCColor.m */; };
+		3F54A0AC14C3535D003D5928 /* MNCAttributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0AB14C3535D003D5928 /* MNCAttributedString.m */; };
 		3F54A0C214C357AC003D5928 /* MNASParagraphyStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0C114C357AC003D5928 /* MNASParagraphyStyle.m */; };
 		3F54A0C514C357B8003D5928 /* MNASGlyphInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0C414C357B8003D5928 /* MNASGlyphInfo.m */; };
 		3F54A0D814C36BD2003D5928 /* MNASTextTab.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0D714C36BD2003D5928 /* MNASTextTab.m */; };
@@ -54,13 +54,13 @@
 		3F18E44814B7D79700303392 /* MNArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = MNArchiver.m; path = ../MNCoder/MNArchiver.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		3F18E44E14B7D8B900303392 /* MNUnarchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNUnarchiver.h; path = ../MNCoder/MNUnarchiver.h; sourceTree = "<group>"; };
 		3F18E44F14B7D8B900303392 /* MNUnarchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNUnarchiver.m; path = ../MNCoder/MNUnarchiver.m; sourceTree = "<group>"; };
-		3F18E45E14B7DB4600303392 /* MNFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNFont.h; path = ../MNCoder/IntermediateObjects/MNFont.h; sourceTree = "<group>"; };
-		3F18E45F14B7DB4600303392 /* MNFont.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNFont.m; path = ../MNCoder/IntermediateObjects/MNFont.m; sourceTree = "<group>"; };
-		3F18E46114B7DB5300303392 /* MNColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNColor.h; path = ../MNCoder/IntermediateObjects/MNColor.h; sourceTree = "<group>"; };
-		3F18E46214B7DB5300303392 /* MNColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNColor.m; path = ../MNCoder/IntermediateObjects/MNColor.m; sourceTree = "<group>"; };
+		3F18E45E14B7DB4600303392 /* MNCFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCFont.h; path = ../MNCoder/IntermediateObjects/MNCFont.h; sourceTree = "<group>"; };
+		3F18E45F14B7DB4600303392 /* MNCFont.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNCFont.m; path = ../MNCoder/IntermediateObjects/MNCFont.m; sourceTree = "<group>"; };
+		3F18E46114B7DB5300303392 /* MNCColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCColor.h; path = ../MNCoder/IntermediateObjects/MNCColor.h; sourceTree = "<group>"; };
+		3F18E46214B7DB5300303392 /* MNCColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNCColor.m; path = ../MNCoder/IntermediateObjects/MNCColor.m; sourceTree = "<group>"; };
 		3F2E56DB14B82A3800B9A12E /* MNCIntermediateObjectProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCIntermediateObjectProtocol.h; path = ../MNCoder/MNCIntermediateObjectProtocol.h; sourceTree = "<group>"; };
-		3F54A0AA14C3535D003D5928 /* MNAttributedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNAttributedString.h; path = ../MNCoder/IntermediateObjects/MNAttributedString.h; sourceTree = "<group>"; };
-		3F54A0AB14C3535D003D5928 /* MNAttributedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNAttributedString.m; path = ../MNCoder/IntermediateObjects/MNAttributedString.m; sourceTree = "<group>"; };
+		3F54A0AA14C3535D003D5928 /* MNCAttributedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCAttributedString.h; path = ../MNCoder/IntermediateObjects/MNCAttributedString.h; sourceTree = "<group>"; };
+		3F54A0AB14C3535D003D5928 /* MNCAttributedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNCAttributedString.m; path = ../MNCoder/IntermediateObjects/MNCAttributedString.m; sourceTree = "<group>"; };
 		3F54A0C014C357AC003D5928 /* MNASParagraphyStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MNASParagraphyStyle.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		3F54A0C114C357AC003D5928 /* MNASParagraphyStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MNASParagraphyStyle.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		3F54A0C314C357B8003D5928 /* MNASGlyphInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MNASGlyphInfo.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -184,13 +184,13 @@
 		3F18E45C14B7DB2C00303392 /* Intermediate Objects */ = {
 			isa = PBXGroup;
 			children = (
-				3F54A0AA14C3535D003D5928 /* MNAttributedString.h */,
-				3F54A0AB14C3535D003D5928 /* MNAttributedString.m */,
+				3F54A0AA14C3535D003D5928 /* MNCAttributedString.h */,
+				3F54A0AB14C3535D003D5928 /* MNCAttributedString.m */,
 				3F54A0A914C3535D003D5928 /* NSAttributedStrings */,
-				3F18E45E14B7DB4600303392 /* MNFont.h */,
-				3F18E45F14B7DB4600303392 /* MNFont.m */,
-				3F18E46114B7DB5300303392 /* MNColor.h */,
-				3F18E46214B7DB5300303392 /* MNColor.m */,
+				3F18E45E14B7DB4600303392 /* MNCFont.h */,
+				3F18E45F14B7DB4600303392 /* MNCFont.m */,
+				3F18E46114B7DB5300303392 /* MNCColor.h */,
+				3F18E46214B7DB5300303392 /* MNCColor.m */,
 			);
 			name = "Intermediate Objects";
 			sourceTree = "<group>";
@@ -298,9 +298,9 @@
 				3F18E41114B7D6EE00303392 /* MNAppDelegate.m in Sources */,
 				3F18E44914B7D79700303392 /* MNArchiver.m in Sources */,
 				3F18E45014B7D8B900303392 /* MNUnarchiver.m in Sources */,
-				3F18E46014B7DB4600303392 /* MNFont.m in Sources */,
-				3F18E46314B7DB5300303392 /* MNColor.m in Sources */,
-				3F54A0AC14C3535D003D5928 /* MNAttributedString.m in Sources */,
+				3F18E46014B7DB4600303392 /* MNCFont.m in Sources */,
+				3F18E46314B7DB5300303392 /* MNCColor.m in Sources */,
+				3F54A0AC14C3535D003D5928 /* MNCAttributedString.m in Sources */,
 				3F54A0C214C357AC003D5928 /* MNASParagraphyStyle.m in Sources */,
 				3F54A0C514C357B8003D5928 /* MNASGlyphInfo.m in Sources */,
 				3F54A0D814C36BD2003D5928 /* MNASTextTab.m in Sources */,

--- a/iOS/iOS.xcodeproj/project.pbxproj
+++ b/iOS/iOS.xcodeproj/project.pbxproj
@@ -17,9 +17,9 @@
 		3F18E44014B7D74600303392 /* MNViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3F18E43E14B7D74600303392 /* MNViewController.xib */; };
 		3F18E44D14B7D7A300303392 /* MNArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E44C14B7D7A300303392 /* MNArchiver.m */; };
 		3F18E45314B7D8C800303392 /* MNUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E45214B7D8C800303392 /* MNUnarchiver.m */; };
-		3F18E46914B7DB5800303392 /* MNFont.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E46614B7DB5800303392 /* MNFont.m */; };
-		3F18E46A14B7DB5800303392 /* MNColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E46814B7DB5800303392 /* MNColor.m */; };
-		3F54A0B014C35365003D5928 /* MNAttributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0AF14C35365003D5928 /* MNAttributedString.m */; };
+		3F18E46914B7DB5800303392 /* MNCFont.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E46614B7DB5800303392 /* MNCFont.m */; };
+		3F18E46A14B7DB5800303392 /* MNCColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F18E46814B7DB5800303392 /* MNCColor.m */; };
+		3F54A0B014C35365003D5928 /* MNCAttributedString.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0AF14C35365003D5928 /* MNCAttributedString.m */; };
 		3F54A0CA14C35DD9003D5928 /* MNASParagraphyStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0C714C35DD9003D5928 /* MNASParagraphyStyle.m */; };
 		3F54A0CB14C35DD9003D5928 /* MNASGlyphInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F54A0C914C35DD9003D5928 /* MNASGlyphInfo.m */; };
 		3F54A0CD14C36251003D5928 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F54A0CC14C36251003D5928 /* CoreText.framework */; };
@@ -66,13 +66,13 @@
 		3F18E44C14B7D7A300303392 /* MNArchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MNArchiver.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		3F18E45114B7D8C400303392 /* MNUnarchiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MNUnarchiver.h; sourceTree = "<group>"; };
 		3F18E45214B7D8C800303392 /* MNUnarchiver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MNUnarchiver.m; sourceTree = "<group>"; };
-		3F18E46514B7DB5800303392 /* MNFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNFont.h; path = ../MNCoder/IntermediateObjects/MNFont.h; sourceTree = "<group>"; };
-		3F18E46614B7DB5800303392 /* MNFont.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNFont.m; path = ../MNCoder/IntermediateObjects/MNFont.m; sourceTree = "<group>"; };
-		3F18E46714B7DB5800303392 /* MNColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNColor.h; path = ../MNCoder/IntermediateObjects/MNColor.h; sourceTree = "<group>"; };
-		3F18E46814B7DB5800303392 /* MNColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNColor.m; path = ../MNCoder/IntermediateObjects/MNColor.m; sourceTree = "<group>"; };
+		3F18E46514B7DB5800303392 /* MNCFont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCFont.h; path = ../MNCoder/IntermediateObjects/MNCFont.h; sourceTree = "<group>"; };
+		3F18E46614B7DB5800303392 /* MNCFont.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNCFont.m; path = ../MNCoder/IntermediateObjects/MNCFont.m; sourceTree = "<group>"; };
+		3F18E46714B7DB5800303392 /* MNCColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCColor.h; path = ../MNCoder/IntermediateObjects/MNCColor.h; sourceTree = "<group>"; };
+		3F18E46814B7DB5800303392 /* MNCColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNCColor.m; path = ../MNCoder/IntermediateObjects/MNCColor.m; sourceTree = "<group>"; };
 		3F2E56DD14B82A4F00B9A12E /* MNCIntermediateObjectProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MNCIntermediateObjectProtocol.h; sourceTree = "<group>"; };
-		3F54A0AE14C35365003D5928 /* MNAttributedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNAttributedString.h; path = ../MNCoder/IntermediateObjects/MNAttributedString.h; sourceTree = "<group>"; };
-		3F54A0AF14C35365003D5928 /* MNAttributedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNAttributedString.m; path = ../MNCoder/IntermediateObjects/MNAttributedString.m; sourceTree = "<group>"; };
+		3F54A0AE14C35365003D5928 /* MNCAttributedString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MNCAttributedString.h; path = ../MNCoder/IntermediateObjects/MNCAttributedString.h; sourceTree = "<group>"; };
+		3F54A0AF14C35365003D5928 /* MNCAttributedString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MNCAttributedString.m; path = ../MNCoder/IntermediateObjects/MNCAttributedString.m; sourceTree = "<group>"; };
 		3F54A0C614C35DD9003D5928 /* MNASParagraphyStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MNASParagraphyStyle.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		3F54A0C714C35DD9003D5928 /* MNASParagraphyStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MNASParagraphyStyle.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		3F54A0C814C35DD9003D5928 /* MNASGlyphInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = MNASGlyphInfo.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -207,13 +207,13 @@
 		3F18E46414B7DB5800303392 /* Intermediate Objects */ = {
 			isa = PBXGroup;
 			children = (
-				3F54A0AE14C35365003D5928 /* MNAttributedString.h */,
-				3F54A0AF14C35365003D5928 /* MNAttributedString.m */,
+				3F54A0AE14C35365003D5928 /* MNCAttributedString.h */,
+				3F54A0AF14C35365003D5928 /* MNCAttributedString.m */,
 				3F54A0AD14C35365003D5928 /* NSAttributedStrings */,
-				3F18E46514B7DB5800303392 /* MNFont.h */,
-				3F18E46614B7DB5800303392 /* MNFont.m */,
-				3F18E46714B7DB5800303392 /* MNColor.h */,
-				3F18E46814B7DB5800303392 /* MNColor.m */,
+				3F18E46514B7DB5800303392 /* MNCFont.h */,
+				3F18E46614B7DB5800303392 /* MNCFont.m */,
+				3F18E46714B7DB5800303392 /* MNCColor.h */,
+				3F18E46814B7DB5800303392 /* MNCColor.m */,
 			);
 			name = "Intermediate Objects";
 			path = ../Mac;
@@ -356,9 +356,9 @@
 				3F18E43D14B7D74600303392 /* MNViewController.m in Sources */,
 				3F18E44D14B7D7A300303392 /* MNArchiver.m in Sources */,
 				3F18E45314B7D8C800303392 /* MNUnarchiver.m in Sources */,
-				3F18E46914B7DB5800303392 /* MNFont.m in Sources */,
-				3F18E46A14B7DB5800303392 /* MNColor.m in Sources */,
-				3F54A0B014C35365003D5928 /* MNAttributedString.m in Sources */,
+				3F18E46914B7DB5800303392 /* MNCFont.m in Sources */,
+				3F18E46A14B7DB5800303392 /* MNCColor.m in Sources */,
+				3F54A0B014C35365003D5928 /* MNCAttributedString.m in Sources */,
 				3F54A0CA14C35DD9003D5928 /* MNASParagraphyStyle.m in Sources */,
 				3F54A0CB14C35DD9003D5928 /* MNASGlyphInfo.m in Sources */,
 				3F54A0DC14C36BD7003D5928 /* MNASTextTab.m in Sources */,


### PR DESCRIPTION
Those changes were necessary to not conflict with MindNode's MNColor and MNFont classes used for Mac and iOS abstraction.
